### PR TITLE
Processing update requires java imports

### DIFF
--- a/processing/SynapseReceiver/Skeleton.pde
+++ b/processing/SynapseReceiver/Skeleton.pde
@@ -3,6 +3,8 @@
 // http://synapsekinect.tumblr.com/post/6307752257/maxmsp-jitter
 //
 
+import java.util.Map;
+import java.util.Iterator;
 import java.util.HashMap;
 import oscP5.*;
 import netP5.*;


### PR DESCRIPTION
Heya, your examples were complaining about missing the types above, apparently the newest Processing doesn't import them by default.
